### PR TITLE
Add script to run a batched ICMP pinger

### DIFF
--- a/scripts/icmp-pinger/README.md
+++ b/scripts/icmp-pinger/README.md
@@ -1,0 +1,5 @@
+# Script to run an ICMP pinger code
+
+To run: `go run batched-icmp.go --inputfile iplist.txt --outputfile icmp-output.jsonl`
+
+where input file `iplist.txt` is a newline delimited list of IPs to which you are interested in sending ICMP pings, it outputs JSON lines.

--- a/scripts/icmp-pinger/batched-icmp.go
+++ b/scripts/icmp-pinger/batched-icmp.go
@@ -57,13 +57,13 @@ func fmtTimeMs(value time.Duration) float64 {
 }
 
 func main() {
-	var logfilePath string
+	var outputfilePath string
 	var ipfilePath string
-	flag.StringVar(&logfilePath, "logfile", "output.jsonl", "Path to log file")
+	flag.StringVar(&outputfilePath, "outputfile", "output.jsonl", "Path to output file")
 	flag.StringVar(&ipfilePath, "inputfile", "ip-list.txt", "Path to input IP file")
 	flag.Parse()
 
-	file, err := os.OpenFile(logfilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	file, err := os.OpenFile(outputfilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/scripts/icmp-pinger/batched-icmp.go
+++ b/scripts/icmp-pinger/batched-icmp.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/go-ping/ping"
+	"log"
+	"math"
+	"os"
+	"sync"
+	"time"
+)
+
+var (
+	InfoLogger *log.Logger
+)
+
+const ICMPCount = 5
+const ICMPTimeout = time.Second * 10
+const batchSizeLimit int = 200 // rate becomes roughly 1000 per batch
+
+type RtItem struct {
+	IP        string
+	PktSent   int
+	PktRecv   int
+	PktLoss   float64
+	MinRtt    float64
+	AvgRtt    float64
+	MaxRtt    float64
+	StdDevRtt float64
+}
+
+// From proxy-detection-server icmp pinger code
+func IcmpPing(ip string) string {
+	pinger, err := ping.NewPinger(ip)
+	if err != nil {
+		panic(err)
+	}
+	pinger.Count = ICMPCount
+	pinger.Timeout = ICMPTimeout
+	err = pinger.Run() // Blocks until finished.
+	if err != nil {
+		panic(err)
+	}
+	stat := pinger.Statistics()
+	icmp := RtItem{ip, stat.PacketsSent, stat.PacketsRecv, stat.PacketLoss, fmtTimeMs(stat.MinRtt), fmtTimeMs(stat.AvgRtt), fmtTimeMs(stat.MaxRtt), fmtTimeMs(stat.StdDevRtt)}
+	jsObj, _ := json.Marshal(icmp)
+	resultString := string(jsObj)
+	return resultString
+
+}
+
+func fmtTimeMs(value time.Duration) float64 {
+	return (float64(value) / float64(time.Millisecond))
+}
+
+func main() {
+	var logfilePath string
+	var ipfilePath string
+	flag.StringVar(&logfilePath, "logfile", "output.jsonl", "Path to log file")
+	flag.StringVar(&ipfilePath, "inputfile", "ip-list.txt", "Path to input IP file")
+	flag.Parse()
+
+	file, err := os.OpenFile(logfilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		log.Fatal(err)
+	}
+	InfoLogger = log.New(file, "", 0)
+
+	ipfile, _ := os.Open(ipfilePath)
+
+	content := bufio.NewScanner(ipfile)
+	lines := make([]string, 0)
+	for content.Scan() {
+		lines = append(lines, content.Text())
+	}
+
+	ipTotal := len(lines)
+	offset := 0
+	numBatches := int(math.Ceil(float64(ipTotal / batchSizeLimit)))
+
+	if ipTotal == 0 {
+		log.Fatal("Input file ", ipfilePath, " is empty")
+	}	
+
+	fmt.Println("Number of Batches (of 200 each): ", numBatches)
+	for i := 0; i <= numBatches; i++ {
+		lower := offset
+		upper := offset + batchSizeLimit
+
+		if upper > ipTotal {
+			upper = ipTotal
+		}
+		batchIPs := lines[lower:upper]
+		offset += batchSizeLimit
+
+		var itemProcessingGroup sync.WaitGroup
+		itemProcessingGroup.Add(len(batchIPs))
+
+		for id := range batchIPs {
+			go func(IP string, id int) {
+				defer itemProcessingGroup.Done()
+				resultString := IcmpPing(IP)
+				InfoLogger.Printf("%s", resultString)
+			}(batchIPs[id], id)
+		}
+		itemProcessingGroup.Wait()
+	}
+}

--- a/scripts/icmp-pinger/go.mod
+++ b/scripts/icmp-pinger/go.mod
@@ -1,0 +1,12 @@
+module batched-icmp.go
+
+go 1.18
+
+require github.com/go-ping/ping v1.1.0
+
+require (
+	github.com/google/uuid v1.2.0 // indirect
+	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005 // indirect
+)

--- a/scripts/icmp-pinger/go.sum
+++ b/scripts/icmp-pinger/go.sum
@@ -1,0 +1,14 @@
+github.com/go-ping/ping v1.1.0 h1:3MCGhVX4fyEUuhsfwPrsEdQw6xspHkv5zHsiSoDFZYw=
+github.com/go-ping/ping v1.1.0/go.mod h1:xIFjORFzTxqIV/tDVGO4eDy/bLuSyawEeojSm3GfRGk=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 h1:b0LrWgu8+q7z4J+0Y3Umo5q1dL7NXBkKBWkaVkAq17E=
+golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005 h1:pDMpM2zh2MT0kHy037cKlSby2nEhD50SYqwQk76Nm40=
+golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
This code can be run to send ICMP queries and record latency to a set of IPs.

First, this was used to ping a whole BGP prefix of a known residential IP and was used to record all the latencies for all pings. Using this we can plot a distribution of the RTTs and see if they are clustered around a certain value, we can then say these IPs are both "adjacent" IPs in terms of BGP prefix (or the /24 prefix) and that the distribution shows that these IPs can be used to estimate RTT for the IP we are actually interested in.