### PR TITLE
Run evaluation of 0trace.sh using RIPE atlas probes

### DIFF
--- a/eval-0trace/0trace.sh
+++ b/eval-0trace/0trace.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+umask 077
+
+T=`mktemp "$HOME/.0trace-XXXXXX"`
+
+if [ "$2" = "" ]; then
+  echo "Usage: $0 iface target_ip [ target_port ]" 1>&2
+  exit 1
+fi
+
+if [ ! -x /bin/usleep ]; then
+  echo "[-] /bin/usleep not found on this system, sorry." 1>&2
+  exit 1
+fi
+
+if [ ! "`uname`" = "Linux" ]; then
+  echo "[-] WARNING: Only Linux is believed to work fine with this utility." 1>&2
+fi
+
+make sendprobe >/dev/null
+test -f ./sendprobe || exit 1
+
+echo "0trace v0.01 PoC by <lcamtuf@coredump.cx>"
+
+RULE="(tcp[13] & 0x17 == 0x10) and src host $2"
+test "$3" = "" || RULE="$RULE and src port $3"
+
+echo "[+] Waiting for traffic from target on $1..."
+
+/usr/sbin/tcpdump -c 1 -s 200 -S -q -i "$1" -n -x "$RULE" >"$T" 2>/dev/null
+
+if [ ! -s "$T" ]; then
+  echo "[-] Something went wrong with tcpdump (check parameters)."
+  rm -f "$T"
+  exit 1
+fi
+
+echo "[+] Traffic acquired, waiting for a gap..."
+
+WAITING=0
+WAITTIME=0
+
+while [ "$WAITTIME" -lt "80" ]; do
+  /usr/sbin/tcpdump -c 1 -s 200 -S -q -i "$1" -n -x "$RULE" >"$T-2" 2>/dev/null &
+  TPID="$!"
+  usleep 100000
+
+  while kill -0 "$TPID" 2>/dev/null; do
+    WAITING=$[WAITING+1]
+    if [ "$WAITING" -gt "20" ]; then
+      kill "$TPID" 2>/dev/null
+      break
+    fi
+    usleep 100000
+  done
+  
+  test -s "$T-2" || break
+  WAITING=0
+  cat "$T-2" >"$T"
+  WAITTIME=$[WAITTIME+1]
+  
+done
+
+if  [ "$WAITTIME" -ge "80" ]; then
+  echo "[-] Couldn't find a sufficient period of no activity."
+  exit 1
+fi
+
+cat "$T" | head -3 | tail -1 | sed 's/0x[0-9]*:/ /g' | cut -b25- >"$T-2"
+read A1 A2 S1 S2 <"$T-2"
+cat "$T" | head -1 | sed 's/IP //' | cut -d' ' -f2,4 | sed  's/\.\([0-9]*\)[: ]/ \1 /g' >"$T-2"
+read DADDR DPORT SADDR SPORT <"$T-2"
+rm -f "$T-2"
+
+SEQ=`printf "%u" 0x$S1$S2`
+ACK=`printf "%u" 0x$A1$A2`
+
+echo "[+] Target acquired: $SADDR:$SPORT -> $DADDR:$DPORT ($SEQ/$ACK)."
+
+echo "[+] Setting up a sniffer..."
+
+/usr/sbin/tcpdump -l -s 200 -S -q -i "$1" -n -x "icmp or ($RULE)" >"$T" 2>/dev/null &
+TPID="$!"
+
+echo "[+] Sending probes..."
+
+./sendprobe $SADDR $DADDR $SPORT $DPORT $SEQ $ACK
+sleep 2
+kill "$TPID" 2>/dev/null
+
+echo 
+echo "TRACE RESULTS"
+echo "-------------"
+
+cat "$T" | sed 's/ IP//g;s/^[ 	]*0x[0-9]*: //g' | grep -vE '45.0 00' | grep -iA1 'time.excee' | \
+  grep -vE '^--' | cut -d' ' -f2 | \
+  sed 's/\([0-9a-f][0-9a-f]\)[0][0]$/\1/g' | \
+  awk '{if (NR%2) {SAVE=$0} else {print $0 " " SAVE}}' | \
+  grep -v '[0-9a-f][0-9a-f][0-9a-f][0-9a-f]' | \
+  while read -r num dat; do echo "$[0x$num] $dat"; done | sort -n -u
+
+if grep -qF ': tcp 0' "$T"; then
+  echo "Target reached."
+else
+  echo "Probe rejected by target."
+fi
+
+echo
+
+rm -f "$T"
+
+exit 1 
+

--- a/eval-0trace/README.md
+++ b/eval-0trace/README.md
@@ -1,0 +1,8 @@
+# Script to run the evaluation of the 0trace method
+
+On sudo, run: `./sync-wrapper.sh` 
+It needs:
+- `inputs/atlas-ip-probeid.txt` which has a newline-delimited file containing comma-separated RIPE Atlas Probe IPs and the corresponding probe-ids
+- `outputs/` directory
+- [RIPE Atlas CLI toolkit](https://ripe-atlas-tools.readthedocs.io/en/latest/installation.html) installed. We use the `asslcert` measurement command which is short for `ripe-atlas measure sslcert`
+    - Must [configure the RIPE Atlas CLI toolkit](https://ripe-atlas-tools.readthedocs.io/en/latest/quickstart.html#creating-a-measurement) to use your API key

--- a/eval-0trace/README.md
+++ b/eval-0trace/README.md
@@ -1,6 +1,11 @@
 # Script to run the evaluation of the 0trace method
 
 On sudo, run: `./sync-wrapper.sh` 
+
+h/t: The script `0trace.sh` and all its components (`sendprobe.c`, `types.h`) was developed by Michal Zalewski, [documented in Bugtraq](https://lwn.net/Articles/217023/), and was [downloaded from here](http://lcamtuf.coredump.cx/soft/0trace.tgz). The script `usleep.c`, necessary for 0trace to run, was obtained [from aldeid/wiki](https://www.aldeid.com/wiki/0trace).
+
+I made a change to `sendprobe.c` to increase the max TTL hop from `30` --> `64`
+
 It needs:
 - `inputs/atlas-ip-probeid.txt` which has a newline-delimited file containing comma-separated RIPE Atlas Probe IPs and the corresponding probe-ids
 - `outputs/` directory

--- a/eval-0trace/go.mod
+++ b/eval-0trace/go.mod
@@ -1,0 +1,12 @@
+module parse-each.go
+
+go 1.18
+
+require github.com/go-ping/ping v1.1.0
+
+require (
+	github.com/google/uuid v1.2.0 // indirect
+	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005 // indirect
+)

--- a/eval-0trace/go.sum
+++ b/eval-0trace/go.sum
@@ -1,0 +1,14 @@
+github.com/go-ping/ping v1.1.0 h1:3MCGhVX4fyEUuhsfwPrsEdQw6xspHkv5zHsiSoDFZYw=
+github.com/go-ping/ping v1.1.0/go.mod h1:xIFjORFzTxqIV/tDVGO4eDy/bLuSyawEeojSm3GfRGk=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 h1:b0LrWgu8+q7z4J+0Y3Umo5q1dL7NXBkKBWkaVkAq17E=
+golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005 h1:pDMpM2zh2MT0kHy037cKlSby2nEhD50SYqwQk76Nm40=
+golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/eval-0trace/inputs/parse-ripe-probe-data.rb
+++ b/eval-0trace/inputs/parse-ripe-probe-data.rb
@@ -1,0 +1,68 @@
+# Feed in the json file extracted from https://ftp.ripe.net/ripe/atlas/probes/archive/2022/07/
+# I downloaded: 20220719.json.bz2, and extracted it
+# run script as: ruby parse-ripe-probe-data.rb 20220719.json list-of-probes.jsonl atlas-ip-probeid.txt
+require 'json'
+
+def checktags(json)
+	x = json["tags"]
+	if x.include?("home")
+		return true
+	end
+	return false	
+end
+
+ip = File.open(ARGV[0], 'r')
+op = File.open(ARGV[1], 'w')
+op2 = File.open(ARGV[2], 'w')
+
+ipHash = Hash.new
+ip.each_line do |line|
+	json_list = JSON.parse(line)
+	json_list.each do |json|
+		if json["address_v4"] != nil and json["status_name"] == "Connected" and checktags(json)	
+			op.puts JSON.dump(json)
+			op2.puts json["address_v4"] + "," + json["id"].to_s
+		end
+	end
+end
+
+=begin
+Example probe that passes the checks in this program: 
+	{
+	"id": 1000,
+	"address_v4": "144.134.116.134",
+	"address_v6": "2001:8003:7105:c200:220:4aff:fec7:b000",
+	"asn_v4": 1221,
+	"asn_v6": 1221,
+	"prefix_v4": "144.132.0.0/14",
+	"prefix_v6": "2001:8000::/20",
+	"is_anchor": false,
+	"is_public": true,
+	"status": 1,
+	"status_since": 1658106332,
+	"first_connected": 1307310425,
+	"total_uptime": 307376881,
+	"tags": [
+		"system-ipv6-stable-1d",
+		"system-ipv4-stable-1d",
+		"system-resolves-aaaa-correctly",
+		"system-resolves-a-correctly",
+		"system-ipv6-works",
+		"system-ipv4-works",
+		"system-ipv4-capable",
+		"system-ipv4-rfc1918",
+		"system-ipv6-capable",
+		"cable",
+		"home",
+		"nat",
+		"ipv4",
+		"system-v1"
+	],
+	"country_code": "AU",
+	"latitude": -27.4225,
+	"longitude": 153.0275,
+	"day": "20220719",
+	"probe": "https://atlas.ripe.net/api/v2/probes/1000/",
+	"status_name": "Connected"
+	}
+=end

--- a/eval-0trace/parse-each.go
+++ b/eval-0trace/parse-each.go
@@ -182,13 +182,26 @@ func main() {
 
 	if len(result) > 0 {
 		last, client := runIcmpPingForEval(lastHop, clientIP)
-		fullResult := Result{Timestamp: time.Now().UTC().Format("2006-01-02T15:04:05.000000"), ClientIP: clientIP, Traceroute: result, Lasthop: lastHop, Lastping: last, ClientPing: client}
+		fullResult := Result{
+			Timestamp:  time.Now().UTC().Format("2006-01-02T15:04:05.000000"),
+			ClientIP:   clientIP,
+			Traceroute: result,
+			Lasthop:    lastHop,
+			Lastping:   last,
+			ClientPing: client,
+		}
 		logStructasJson(fullResult, InfoLogger)
 
 		diff, ok := calcAvgDifference(last, client)
+		// do not log if we were unable to obtain either of the RTTs
 		if ok {
-			// do not log if we were unable to obtain either of the RTTs
-			rttStat := AvgRTTcompare{Timestamp: time.Now().UTC().Format("2006-01-02T15:04:05.000000"), ClientIP: clientIP, LastHop: last.AvgRtt, ClientHop: client.AvgRtt, Difference: diff}
+			rttStat := AvgRTTcompare{
+				Timestamp:  time.Now().UTC().Format("2006-01-02T15:04:05.000000"),
+				ClientIP:   clientIP,
+				LastHop:    last.AvgRtt,
+				ClientHop:  client.AvgRtt,
+				Difference: diff,
+			}
 			logStructasJson(rttStat, EvalLogger)
 		}
 	}

--- a/eval-0trace/parse-each.go
+++ b/eval-0trace/parse-each.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"github.com/go-ping/ping"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	InfoLogger *log.Logger
+	EvalLogger *log.Logger
+)
+
+type Hops struct {
+	Hop int
+	IP  string
+}
+
+type Result struct {
+	ClientIP   string
+	Traceroute []Hops
+	Lasthop    string
+	Lastping   RtItem
+	ClientPing RtItem
+}
+
+type AvgRTTcompare struct {
+	ClientIP	string
+	LastHop    float64
+	ClientHop  float64
+	Difference float64
+}
+
+const ICMPCount = 5
+const ICMPTimeout = time.Second * 10
+const batchSizeLimit int = 200 // rate becomes roughly 1000 per batch
+
+type RtItem struct {
+	IP        string
+	PktSent   int
+	PktRecv   int
+	PktLoss   float64
+	MinRtt    float64
+	AvgRtt    float64
+	MaxRtt    float64
+	StdDevRtt float64
+}
+
+// From proxy-detection-server icmp pinger code
+func IcmpPing(ip string) (RtItem, error) {
+	pinger, err := ping.NewPinger(ip)
+	if err != nil {
+		log.Println(err)
+		return RtItem{}, err
+	}
+	pinger.Count = ICMPCount
+	pinger.Timeout = ICMPTimeout
+	err = pinger.Run() // Blocks until finished.
+	if err != nil {
+		log.Println(err)
+		return RtItem{}, err
+	}
+	stat := pinger.Statistics()
+	icmp := RtItem{ip, stat.PacketsSent, stat.PacketsRecv, stat.PacketLoss, fmtTimeMs(stat.MinRtt), fmtTimeMs(stat.AvgRtt), fmtTimeMs(stat.MaxRtt), fmtTimeMs(stat.StdDevRtt)}
+	// jsObj, _ := json.Marshal(icmp)
+	// resultString := string(jsObj)
+	return icmp, nil
+
+}
+
+func calcAvgDifference(last RtItem, client RtItem) (float64, bool) {
+	if last.AvgRtt == 0 || client.AvgRtt == 0 {
+		return 0, false
+	}
+	return client.AvgRtt - last.AvgRtt, true
+}
+
+func fmtTimeMs(value time.Duration) float64 {
+	return (float64(value) / float64(time.Millisecond))
+}
+
+func main() {
+	var outputfilePath string
+	var evalrttfilePath string
+	var tracefile string
+	flag.StringVar(&outputfilePath, "outputfile", "output.jsonl", "Path to full output file")
+	flag.StringVar(&evalrttfilePath, "evalrttfile", "eval-rtt.jsonl", "Path to eval rtt file")
+	flag.StringVar(&tracefile, "tracefile", "", "Path to input 0trace file")
+	flag.Parse()
+
+	file, err := os.OpenFile(outputfilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		log.Fatal(err)
+	}
+	InfoLogger = log.New(file, "", 0)
+
+	evalfile, err := os.OpenFile(evalrttfilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	EvalLogger = log.New(evalfile, "", 0)
+
+	clientparts := strings.Split(tracefile, ".txt")
+	ipPath := clientparts[0]
+	ipsplit := strings.Split(ipPath, "/")
+	clientIP := ipsplit[len(ipsplit)-1]
+	readfile, _ := os.Open(tracefile)
+	content := bufio.NewScanner(readfile)
+	found := false
+	var result []Hops
+	var lastHop string
+
+	allLines := make([]string, 0)
+	for content.Scan() {
+		allLines = append(allLines, content.Text())
+	}
+	for _, lines := range allLines {
+		if strings.Contains(lines, "TRACE RESULTS") {
+			found = true
+			continue
+		}
+		if !found {
+			continue
+		}
+		parts := strings.Split(lines, " ")
+		hop := parts[0]
+		hopInt, _ := strconv.Atoi(hop)
+		if hopInt == 0 || len(parts) == 1 {
+			continue
+		} else {
+			ipaddr := parts[1]
+			currHop := Hops{Hop: hopInt, IP: ipaddr}
+			lastHop = ipaddr
+			result = append(result, currHop)
+		}
+	}
+	if len(result) == 0 {
+		found = false
+	}
+	if found == true {
+		last, err := IcmpPing(lastHop)
+		if err != nil {
+			InfoLogger.Fatal("IcmpPing fail file: ", file, " err: ", err)
+		}
+		client, err := IcmpPing(clientIP)
+		if err != nil {
+			InfoLogger.Fatal("IcmpPing fail file: ", file, " err: ", err)
+		}
+		fullResult := Result{ClientIP: clientIP, Traceroute: result, Lasthop: lastHop, Lastping: last, ClientPing: client}
+		diff, ok := calcAvgDifference(last, client)
+		if ok {
+			rttStat := AvgRTTcompare{ClientIP: clientIP, LastHop: last.AvgRtt, ClientHop: client.AvgRtt, Difference: diff}
+			rttResult, err := json.Marshal(rttStat)
+			if err != nil {
+				EvalLogger.Println("Error logging RTT diff results: ", err)
+				EvalLogger.Println(rttResult) // Dump results in non-JSON format
+			}
+			rttStatString := string(rttResult)
+			EvalLogger.Println(rttStatString)
+		}
+		traceResult, err := json.Marshal(fullResult)
+		if err != nil {
+			InfoLogger.Println("Error logging 0trace results: ", err)
+			InfoLogger.Println(fullResult) // Dump results in non-JSON format
+		}
+		traceString := string(traceResult)
+		InfoLogger.Println(traceString)
+	}
+
+}

--- a/eval-0trace/sendprobe.c
+++ b/eval-0trace/sendprobe.c
@@ -16,7 +16,7 @@
 
 #define fatal(x) do { perror(x); exit(1); } while (0)
 
-#define MAXDIST     30
+#define MAXDIST     64
 #define MAXSEQDELTA 3
 
 static _u8 synpacket[] = {

--- a/eval-0trace/sendprobe.c
+++ b/eval-0trace/sendprobe.c
@@ -1,0 +1,137 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/udp.h>
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <sys/socket.h>
+#include <errno.h>
+
+#include "types.h"
+
+#define fatal(x) do { perror(x); exit(1); } while (0)
+
+#define MAXDIST     30
+#define MAXSEQDELTA 3
+
+static _u8 synpacket[] = {
+
+  /* IP HEADER */
+
+  /* IHL    */ 0x45,
+  /* ToS    */ 0x00,
+  /* totlen */ 0x00, 0x28 + 2,
+  /* ID     */ 0x00, 0x00,   /* id: [4] */
+  /* offset */ 0x00, 0x00,
+  /* TTL    */ 0xFF,         /* ttl: [8] */
+  /* proto  */ 0x06,
+  /* cksum */  0x00, 0x00,
+  /* saddr */  0, 0, 0, 0,   /* src: [12] */
+  /* daddr */  0, 0, 0, 0,   /* dst: [16] */
+
+  /* TCP HEADER - [20] */
+
+  /* sport */  0, 0,         /* sp: [20] */
+  /* dport */  0, 0,	     /* dp: [22] */
+  /* SEQ   */  0, 0, 0, 0,   /* seq: [24] */
+  /* ACK   */  0, 0, 0, 0,   /* ack: [28] */
+  /* doff  */  0x50,
+  /* flags */  0x10,         /* ACK */
+  /* wss   */  0xFF, 0xFF,
+  /* cksum */  0x00, 0x00,   /* cksum: [36] */
+  /* urg   */  0x00, 0x00,
+  
+  0, 0
+  
+};
+
+
+_u16 simple_tcp_cksum(void) {
+  _u32 sum = 26 + 2 /* tcp, len 20 */;
+  _u8  i;
+  _u8* p = synpacket + 20;
+
+  for (i=0;i<10 + 1;i++) {
+    sum += (*p << 8) + *(p+1);
+    p+=2;
+  }
+
+  p = synpacket + 12;
+  
+  for (i=0;i<4;i++) {
+    sum += (*p << 8) + *(p+1);
+    p+=2;
+  }
+
+  return ~(sum + (sum >> 16));
+
+}
+
+
+
+int main(int argc, char** argv) {
+
+  static struct sockaddr_in sain;
+  _s32 sad,dad;
+  _s32 sock, one = 1, i, d;
+  _u16 sp,dp,ck;
+  _u32 seq, ack, seq_o;
+
+  if (argc - 7 || (sad=inet_addr(argv[1])) == INADDR_NONE || 
+     (dad=inet_addr(argv[2])) == INADDR_NONE || !(sp=atoi(argv[3])) ||
+     !(dp=atoi(argv[4])) || (sscanf(argv[5],"%lu",&seq_o) != 1) ||
+     (sscanf(argv[6],"%lu",&ack) != 1)) {
+    fprintf(stderr,"Usage: %s src_ip dst_ip sport dport seq ack\n",argv[0]);
+    exit(1);
+  }
+  
+  sock=socket(AF_INET,SOCK_RAW,IPPROTO_RAW);
+  
+  if (sock<0) fatal("socket");
+  
+  if (setsockopt(sock,IPPROTO_IP,IP_HDRINCL,(char *)&one,sizeof(one)))
+    fatal("setsockopt");
+
+  sain.sin_family = AF_INET;
+  memcpy(&sain.sin_addr.s_addr,&dad,4);
+
+  memcpy(synpacket+12,&sad,4);
+  memcpy(synpacket+16,&dad,4);
+  sp=htons(sp);
+  memcpy(synpacket+20,&sp,2);
+  dp=htons(dp);
+  memcpy(synpacket+22,&dp,2);
+  ack=htonl(ack);
+  memcpy(synpacket+28,&ack,4);
+
+  for (d=1;d<MAXSEQDELTA;d++) {
+
+    seq=htonl(seq_o+d);
+    memcpy(synpacket+24,&seq,4);
+  
+    for (i=0;i<MAXDIST;i++) {
+  
+      synpacket[4] = i;
+      synpacket[8] = i;
+
+      memset(synpacket+36,0,2);
+      ck=simple_tcp_cksum();
+      ck=htons(ck);
+      memcpy(synpacket+36,&ck,2);
+
+      if (sendto(sock,synpacket,sizeof(synpacket), 0,(struct sockaddr *)&sain,
+        sizeof(struct sockaddr)) < 0) perror("sendto");
+      usleep(1000);
+    }
+
+  }
+
+  return 0;
+    
+}
+

--- a/eval-0trace/sync-wrapper.sh
+++ b/eval-0trace/sync-wrapper.sh
@@ -1,0 +1,13 @@
+#Run this script as sudo: 0trace.sh needs sudo access
+#!/bin/bash
+export PATH=$PATH:/usr/local/go/bin
+ulimit -n 10000
+for ipprobe in $(cat inputs/atlas-ip-probeid.txt); do
+	echo "ip,probe $ipprobe"
+	IFS=, read -r ip probe <<< $ipprobe
+	./0trace.sh eth0 $ip > outputs/${ip}.txt &
+	asslcert --target test.reethika.info --from-probes=$probe --no-report
+	sleep 30s
+	pkill 0trace.sh
+	go run parse-each.go --outputfile=output-run.jsonl --evalrttfile=eval-run.jsonl --tracefile=outputs/${ip}.txt
+done

--- a/eval-0trace/types.h
+++ b/eval-0trace/types.h
@@ -1,0 +1,35 @@
+/*
+
+   p0f - type definitions
+   ----------------------
+  
+   Short and portable names for various integer types.
+
+   Copyright (C) 2003-2006 by Michal Zalewski <lcamtuf@coredump.cx>
+
+*/
+
+#ifndef _HAVE_TYPES_H
+#define _HAVE_TYPES_H
+
+typedef unsigned char		_u8;
+typedef unsigned short		_u16;
+typedef unsigned int		_u32;
+
+#ifdef WIN32
+typedef unsigned __int64	_u64;
+#else
+typedef unsigned long long	_u64;
+#endif /* ^WIN32 */
+
+typedef signed char		_s8;
+typedef signed short		_s16;
+typedef signed int		_s32;
+
+#ifdef WIN32
+typedef signed __int64	_s64;
+#else
+typedef signed long long	_s64;
+#endif /* ^WIN32 */
+
+#endif /* ! _HAVE_TYPES_H */

--- a/eval-0trace/usleep.c
+++ b/eval-0trace/usleep.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+int main (int argc, char **argv) {
+usleep(atoi(argv[1]));
+return 0;
+}


### PR DESCRIPTION
Scripts to run the evaluation of the `0trace` method. The script fires 0trace measurements, RIPE Atlas measurements to trigger the 0trace and then parses it to obtain the last hop RTT and direct-to-probe RTT. 

The `eval-run.jsonl` contains the difference in RTT on which I run: 
`jq '.Difference' eval-run.jsonl | awk '{ if ($1 < 0) print -1*$1; else print $1}' | sort -n > avg-rtt-diff.txt` and then plot on a CDF using a [colab notebook](https://colab.research.google.com/drive/1fFCZrWLoYUhSHnk4FT6N7xjFDb5TQWYw)