### PR TITLE
Changes to measurements for data collection

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -32,7 +32,7 @@ func measureHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		details, err := validateForm(r.FormValue("email"), r.FormValue("exp_type"))
+		details, err := validateForm(r.FormValue("email"), r.FormValue("exp_type"), r.FormValue("location_vpn"), r.FormValue("location_user"))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/handlers.go
+++ b/handlers.go
@@ -85,9 +85,9 @@ func pingHandler(w http.ResponseWriter, r *http.Request) {
 		UUID:   uuid,
 		IPaddr: clientIP,
 		//RFC3339 style UTC date time with added seconds information
-		Timestamp:   time.Now().UTC().Format("2006-01-02T15:04:05.000000"),
-		IcmpPing:    *icmpResults,
-		AvgIcmpStat: icmpResults.AvgRtt,
+		Timestamp:  time.Now().UTC().Format("2006-01-02T15:04:05.000000"),
+		IcmpPing:   *icmpResults,
+		MinIcmpRtt: icmpResults.MinRtt,
 	}
 
 	jsObj, err := json.Marshal(results)

--- a/measure.html
+++ b/measure.html
@@ -26,7 +26,6 @@
       input {
         margin: 10px;
         display: inline-block;
-
       }
     </style>
 
@@ -44,9 +43,9 @@
         <label for="vpn">VPN</label><br>
         <div id="locinfo" style="display:none;">
           <label>Location of VPN server connected (enter city, state):</label><br>
-          <input type="text" name="location_vpn"><br />
+          <input type="text" name="location_vpn" size="30" placeholder="City, state (if applicable), country"><br />
           <label>Your location:</label><br>
-          <input type="text" name="location_user"><br />
+          <input type="text" name="location_user" size="30" placeholder="City, state (if applicable), country"><br />
           <label>We only use this information to reason about the measured latencies and physical distance.</label><br>
           <label>Please enter <i>unknown</i> if you are unsure about VPN server location, or <i>"best available"</i> if you chose that on your VPN.</label><br>
         </div>

--- a/measure.html
+++ b/measure.html
@@ -42,7 +42,7 @@
         <input type="radio" id="exp_type" name="exp_type" value="vpn" onclick="document.getElementById('locinfo').style.display='block'">
         <label for="vpn">VPN</label><br>
         <div id="locinfo" style="display:none;">
-          <label>Location of VPN server connected (enter city, state):</label><br>
+          <label>Location of VPN server connected to (if any):</label><br>
           <input type="text" name="location_vpn" size="30" placeholder="City, state (if applicable), country"><br />
           <label>Your location:</label><br>
           <input type="text" name="location_user" size="30" placeholder="City, state (if applicable), country"><br />

--- a/measure.html
+++ b/measure.html
@@ -47,7 +47,7 @@
           <label>Your location:</label><br>
           <input type="text" name="location_user" size="30" placeholder="City, state (if applicable), country"><br />
           <label>We only use this information to reason about the measured latencies and physical distance.</label><br>
-          <label>Please enter <i>unknown</i> if you are unsure about VPN server location, or <i>"best available"</i> if you chose that on your VPN.</label><br>
+          <label>Please enter <i>"unknown"</i> if you are unsure about your VPN server's location, or <i>"best available"</i> if you chose that in your VPN settings.</label><br>
         </div>
         <input type="submit" onclick="submitHandler()">
         <div id="loading" style="display:none;">

--- a/measure.html
+++ b/measure.html
@@ -48,7 +48,8 @@
           <input type="text" name="location_user" size="30" placeholder="City, state (if applicable), country"><br />
           <label>We only use this information to reason about the measured latencies and physical distance.</label><br>
           <label>Please enter <i>"unknown"</i> if you are unsure about your VPN server's location, or <i>"best available"</i> if you chose that in your VPN settings.</label><br>
-        </div>
+        </div><br />
+        <label>Contact @reethika and @phw on Slack if you have any questions.</label><br>
         <input type="submit" onclick="submitHandler()">
         <div id="loading" style="display:none;">
           <button class="buttonload">

--- a/measure.html
+++ b/measure.html
@@ -38,10 +38,18 @@
         <label>Brave Email ID (username@brave.com):</label><br>
         <input type="text" placeholder="username@brave.com" name="email"><br />
         <label>Are you connecting to us through:</label><br>
-        <input type="radio" id="exp_type" name="exp_type" value="direct">
+        <input type="radio" id="exp_type" name="exp_type" value="direct" onclick="document.getElementById('locinfo').style.display='none'">
         <label for="direct">Direct Connection</label><br>
-        <input type="radio" id="exp_type" name="exp_type" value="vpn">
+        <input type="radio" id="exp_type" name="exp_type" value="vpn" onclick="document.getElementById('locinfo').style.display='block'">
         <label for="vpn">VPN</label><br>
+        <div id="locinfo" style="display:none;">
+          <label>Location of VPN server connected (enter city, state):</label><br>
+          <input type="text" name="location_vpn"><br />
+          <label>Location of user (enter city, state):</label><br>
+          <input type="text" name="location_user"><br />
+          <label>We only use this information to reason about the measured latencies and physical distance.</label><br>
+          <label>Please enter <i>unknown</i> if you are unsure about VPN server location, or <i>"best available"</i> if you chose that on your VPN.</label><br>
+        </div>
         <input type="submit" onclick="submitHandler()">
         <div id="loading" style="display:none;">
           <button class="buttonload">

--- a/measure.html
+++ b/measure.html
@@ -45,7 +45,7 @@
         <div id="locinfo" style="display:none;">
           <label>Location of VPN server connected (enter city, state):</label><br>
           <input type="text" name="location_vpn"><br />
-          <label>Location of user (enter city, state):</label><br>
+          <label>Your location:</label><br>
           <input type="text" name="location_user"><br />
           <label>We only use this information to reason about the measured latencies and physical distance.</label><br>
           <label>Please enter <i>unknown</i> if you are unsure about VPN server location, or <i>"best available"</i> if you chose that on your VPN.</label><br>

--- a/networking.go
+++ b/networking.go
@@ -30,11 +30,11 @@ type PingMsmt struct {
 }
 
 type Results struct {
-	UUID        string
-	IPaddr      string
-	Timestamp   string
-	IcmpPing    PingMsmt
-	AvgIcmpStat float64
+	UUID       string
+	IPaddr     string
+	Timestamp  string
+	IcmpPing   PingMsmt
+	MinIcmpRtt float64
 }
 
 // icmpPinger sends ICMP pings and returns statistics

--- a/networking.go
+++ b/networking.go
@@ -12,10 +12,12 @@ const (
 )
 
 type FormDetails struct {
-	UUID      string
-	Timestamp string
-	Contact   string
-	ExpType   string
+	UUID         string
+	Timestamp    string
+	Contact      string
+	ExpType      string
+	LocationVPN  string
+	LocationUser string
 }
 
 type PingMsmt struct {

--- a/pingpage.html
+++ b/pingpage.html
@@ -134,7 +134,7 @@
         document.getElementById('ip').innerHTML = {{ .IPaddr }};
         document.getElementById('values').innerHTML = latencies;
         document.getElementById('data').innerHTML = min(latencies);
-        document.getElementById('icmp').innerHTML = {{ .AvgIcmpStat }};
+        document.getElementById('icmp').innerHTML = {{ .MinIcmpRtt }};
       });
     </script>
   </body>

--- a/pingpage.html
+++ b/pingpage.html
@@ -42,16 +42,14 @@
         loading.style.display = "none";
       }, 120000);
 
-     function median(values){
+      function min(values){
             if (values.length ===0) return 0;
             values.sort(function(a,b){
               return a-b;
             });
-            var half = Math.floor(values.length / 2);
-            if (values.length % 2)
-              return values[half];
-            return (values[half - 1] + values[half]) / 2.0;
+            return values[0];
           }
+
       function roundToTwo(num) {    
         return +(Math.round(num + "e+2")  + "e-2");
       }
@@ -69,6 +67,7 @@
           var messages = [];
           const latencies = [];
           var statsSent = false;
+          const cooldown = 2000; // in ms
 
           socket.onopen = function () {
             socket.send(JSON.stringify({
@@ -77,16 +76,17 @@
             }));
           }
 
-          socket.onmessage = function (event) {
+          socket.onmessage = async function (event) {
             messages.push(JSON.parse(event.data));
-            if (messages.length <= 5) {
+            await new Promise(r => setTimeout(r, cooldown));
+            if (messages.length <= 10) {
               socket.send(JSON.stringify({
                 type: 'ws-latency',
                 ts: roundToTwo(performance.now()),
               }));
             } else {
               for (let i = 0; i < messages.length - 1; i++) {
-                latencies.push(roundToTwo(messages[i+1].ts - messages[i].ts));
+                latencies.push(roundToTwo(messages[i+1].ts - messages[i].ts - cooldown));
               }
               if (statsSent == false) {
               const datetimeutc = new Date().toISOString();
@@ -133,7 +133,7 @@
         document.getElementById('uuid').innerHTML = {{ .UUID }};
         document.getElementById('ip').innerHTML = {{ .IPaddr }};
         document.getElementById('values').innerHTML = latencies;
-        document.getElementById('data').innerHTML = median(latencies);
+        document.getElementById('data').innerHTML = min(latencies);
         document.getElementById('icmp').innerHTML = {{ .AvgIcmpStat }};
       });
     </script>

--- a/util.go
+++ b/util.go
@@ -28,18 +28,27 @@ func logAsJson(obj any, GivenLogger *log.Logger) {
 }
 
 // validateForm validates user input obtained from /measure webpage
-func validateForm(email string, expType string) (*FormDetails, error) {
-	if m, _ := regexp.MatchString(`^\w+@brave\.com$`, email); !m {
+func validateForm(email string, expType string, locationVPN string, locationUser string) (*FormDetails, error) {
+	if match, _ := regexp.MatchString(`^\w+@brave\.com$`, email); !match {
 		return nil, invalidInputErr
 	}
 	if expType != "vpn" && expType != "direct" {
 		return nil, invalidInputErr
 	}
+	if match, _ := regexp.MatchString(`^[\w,.'";:\s\d(){}]*$`, locationVPN); !match {
+		return nil, invalidInputErr
+	}
+	if match, _ := regexp.MatchString(`^[\w,.'";:\s\d(){}]*$`, locationUser); !match {
+		return nil, invalidInputErr
+	}
+
 	details := FormDetails{
-		UUID:      uuid.NewString(),
-		Timestamp: time.Now().UTC().Format("2006-01-02T15:04:05.000000"),
-		Contact:   email,
-		ExpType:   expType,
+		UUID:         uuid.NewString(),
+		Timestamp:    time.Now().UTC().Format("2006-01-02T15:04:05.000000"),
+		Contact:      email,
+		ExpType:      expType,
+		LocationVPN:  locationVPN,
+		LocationUser: locationUser,
 	}
 	return &details, nil
 }

--- a/util_test.go
+++ b/util_test.go
@@ -28,7 +28,7 @@ func AssertError(t *testing.T, err error) {
 
 func TestValidateForm(t *testing.T) {
 	// Send valid email and experiment type, check that returned object is exactly as expected
-	details, err := validateForm("user@brave.com", "vpn")
+	details, err := validateForm("user@brave.com", "vpn", "abc, xyz", "qwe, bnm")
 	if err != nil {
 		t.Fatalf("Expected no error, but got %v", err)
 	}
@@ -36,17 +36,17 @@ func TestValidateForm(t *testing.T) {
 	AssertEqualValue(t, "vpn", details.ExpType)
 
 	// Send invalid email
-	_, err = validateForm("baduser@invalid.com", "vpn")
+	_, err = validateForm("baduser@invalid.com", "vpn", "", "")
 	AssertError(t, err)
 	AssertEqualValue(t, invalidInputErr, err)
 
 	// Send invalid expType
-	_, err = validateForm("user@brave.com", "unknown")
+	_, err = validateForm("user@brave.com", "unknown", "", "")
 	AssertError(t, err)
 	AssertEqualValue(t, invalidInputErr, err)
 
 	// Send empty input
-	_, err = validateForm("", "")
+	_, err = validateForm("", "", "", "")
 	AssertError(t, err)
 	AssertEqualValue(t, invalidInputErr, err)
 }


### PR DESCRIPTION
After one round of internal data collection, we're adapting the measurements for a larger round of data collection:
- [x] Send more websocket RTT measurements, and have a cooldown period between websocket pings. 
- [x] Add another field to input form to get more info about user/VPN location. 
- [x] Use minimum found RTT for both websocket measurement and ICMP ping measurements instead of mean/median.