### PR TITLE
Use "any" interface by default.

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -128,7 +128,7 @@ func traceHandler(w http.ResponseWriter, r *http.Request) {
 	defer c.Close()
 	myConn := c.UnderlyingConn()
 
-	zeroTraceInstance := newZeroTrace(deviceName, myConn, uuid)
+	zeroTraceInstance := newZeroTrace(ifaceName, myConn, uuid)
 
 	err = zeroTraceInstance.Run()
 	if err != nil {

--- a/zerotrace.go
+++ b/zerotrace.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	deviceName string
+	ifaceName string
 )
 
 // SentPacketData struct keeps track of the IP ID value and Sent time for each TCP packet sent


### PR DESCRIPTION
Some systems have a networking interface called "any" which acts as a
pseudo interface.  We want to use that by default.